### PR TITLE
autofocus search on pageload

### DIFF
--- a/src/components/SearchInput.js
+++ b/src/components/SearchInput.js
@@ -53,6 +53,7 @@ function SearchInput({ value, placeholder, label, onChange, ...props }) {
         aria-label={label}
         onChange={onChange}
         pl={56}
+        autoFocus
       />
     </Relative>
   )


### PR DESCRIPTION
save a click interaction and just autofocus search bar so users can immediately search for an icon and grab it quickly!

works for personas who haven't downloaded the entire set, but often come back to feathericons.com to grab one or two quick icons.