### PR TITLE
Add copy-to-clipboard with shift

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2751,6 +2751,14 @@
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
+    "copy-to-clipboard": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.0.8.tgz",
+      "integrity": "sha512-c3GdeY8qxCHGezVb1EFQfHYK/8NZRemgcTIzPq7PuxjHAf/raKibn2QdhHPb/y6q74PMgH6yizaDZlRmw6QyKw==",
+      "requires": {
+        "toggle-selection": "^1.0.3"
+      }
+    },
     "copyfiles": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/copyfiles/-/copyfiles-1.2.0.tgz",
@@ -13057,6 +13065,11 @@
           }
         }
       }
+    },
+    "toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha1-bkWxJj8gF/oKzH2J14sVuL932jI="
     },
     "topo": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "classnames": "2.2.5",
+    "copy-to-clipboard": "^3.0.8",
     "downloadjs": "1.4.7",
     "feather-icons": "^4.14.0",
     "fuse.js": "3.2.0",

--- a/src/components/IconGrid.js
+++ b/src/components/IconGrid.js
@@ -1,4 +1,5 @@
 import download from 'downloadjs'
+import copy from 'copy-to-clipboard'
 import { arrayOf, func, shape, string } from 'prop-types'
 import React from 'react'
 import logDownload from '../utils/logDownload'
@@ -14,9 +15,11 @@ function IconGrid({ icons }) {
           <IconTile
             name={icon.name}
             title={`Download ${icon.name}.svg`}
-            onClick={() => {
-              download(icon.toSvg(), `${icon.name}.svg`, 'image/svg+xml')
+            onClick={e => {
               logDownload(icon.name)
+              return e.shiftKey
+                ? copy(icon.toSvg())
+                : download(icon.toSvg(), `${icon.name}.svg`, 'image/svg+xml')
             }}
           />
         </Box>

--- a/src/components/IconGrid.js
+++ b/src/components/IconGrid.js
@@ -3,6 +3,7 @@ import copy from 'copy-to-clipboard'
 import { arrayOf, func, shape, string } from 'prop-types'
 import React from 'react'
 import logDownload from '../utils/logDownload'
+import logCopy from '../utils/logCopy'
 import Box from './Box'
 import Flex from './Flex'
 import IconTile from './IconTile'
@@ -15,11 +16,14 @@ function IconGrid({ icons }) {
           <IconTile
             name={icon.name}
             title={`Download ${icon.name}.svg`}
-            onClick={e => {
-              logDownload(icon.name)
-              return e.shiftKey
-                ? copy(icon.toSvg())
-                : download(icon.toSvg(), `${icon.name}.svg`, 'image/svg+xml')
+            onClick={event => {
+              if (event.shiftKey) {
+                copy(icon.toSvg())
+                logCopy(icon.name)
+              } else {
+                download(icon.toSvg(), `${icon.name}.svg`, 'image/svg+xml')
+                logDownload(icon.name)
+              }
             }}
           />
         </Box>

--- a/src/utils/logCopy.js
+++ b/src/utils/logCopy.js
@@ -1,0 +1,11 @@
+function logCopy(label) {
+  if (typeof window.ga === 'function') {
+    window.ga('send', 'event', {
+      eventCategory: 'copy',
+      eventAction: 'click',
+      eventLabel: label,
+    })
+  }
+}
+
+export default logCopy


### PR DESCRIPTION
I finally got fed up with inspecting page source and copying SVGs straight from HTML. 😄

This addresses issue #18 - but instead of an additional button I added the ability to simply `shift+click` on an icon and get the SVG copied into clipboard for easy pasting.

![copy](https://user-images.githubusercontent.com/1710629/51990709-e74a7400-24a9-11e9-8b8f-9d32324f3f60.gif)