### PR TITLE
Use rgba() values to fix Safari gradient rendering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7993,6 +7993,11 @@
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ=="
     },
+    "hex-to-rgba": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/hex-to-rgba/-/hex-to-rgba-2.0.1.tgz",
+      "integrity": "sha512-5XqPJBpsEUMsseJUi2w2Hl7cHFFi3+OO10M2pzAvKB1zL6fc+koGMhmBqoDOCB4GemiRM/zvDMRIhVw6EkB8dQ=="
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "gatsby-plugin-manifest": "^2.2.0",
     "gatsby-plugin-react-helmet": "^3.1.0",
     "gatsby-source-filesystem": "^2.1.0",
+    "hex-to-rgba": "^2.0.1",
     "polished": "^1.9.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -11,6 +11,7 @@ import NoResults from '../components/NoResults'
 import SearchInput from '../components/SearchInput'
 import theme from '../theme'
 import useSearch from '../utils/useSearch'
+import hexToRgba from 'hex-to-rgba'
 
 function IndexPage({ location }) {
   const [query, setQuery] = useQueryParam(
@@ -27,8 +28,9 @@ function IndexPage({ location }) {
         css={{
           position: 'sticky',
           top: 0,
-          background: `linear-gradient(0deg, transparent, ${
-            theme.colors.gray[0]
+          background: `linear-gradient(0deg, ${
+            hexToRgba(theme.colors.gray[0], 0) }, ${
+            hexToRgba(theme.colors.gray[0], 1)
           })`,
         }}
       >


### PR DESCRIPTION
First of all: Great project!

But as a loyal Safari (12.1.2) user I’ve noticed some rendering issues regarding the gradient of the search bar.

<img width="1552" alt="Screenshot" src="https://user-images.githubusercontent.com/9950708/65384902-39395600-dd28-11e9-88ae-42347ecf3acb.png">

This is caused by the `transparent` keyword, which Safari [doesn’t like](https://stackoverflow.com/questions/30673204/css-linear-gradient-transparency-misbehaving-only-in-safari) in the context of gradients. The only solution I’m aware of is the use of `rgba()` values instead of `transparent`. Instead of converting all color variables I decided to use a [small library](https://github.com/misund/hex-to-rgba) for this.

I you know a better approach, I’m happy to hear from you.